### PR TITLE
Fix format specifier (add %s for actual error msgs) in errors

### DIFF
--- a/cf/cf.go
+++ b/cf/cf.go
@@ -102,7 +102,7 @@ func (c *CF) Login() error {
 	cmd.Stdout = &msgWriter{"login", "stdout", c.out}
 
 	if err := cmd.Start(); err != nil {
-		fmt.Errorf("Error running cf login: ", err)
+		fmt.Errorf("Error running cf login: %s", err.Error())
 	}
 
 	cmd.Wait()
@@ -114,7 +114,7 @@ func (c *CF) Apps() error {
 	cmd.Env = append(cmd.Env, "CF_HOME="+c.envVar, "CF_COLOR=true")
 	cmd.Stdout = &msgWriter{"apps", "stdout", c.out}
 	if err := cmd.Start(); err != nil {
-		fmt.Errorf("Error running cf apps: ", err)
+		fmt.Errorf("Error running cf apps: %s", err.Error())
 	}
 
 	cmd.Wait()
@@ -126,7 +126,7 @@ func (c *CF) App(appName string) error {
 	cmd.Env = append(cmd.Env, "CF_HOME="+c.envVar, "CF_COLOR=true")
 	cmd.Stdout = &msgWriter{"app", "stdout", c.out}
 	if err := cmd.Start(); err != nil {
-		fmt.Errorf("Error running cf apps: ", err)
+		fmt.Errorf("Error running cf apps: %s", err.Error())
 	}
 
 	cmd.Wait()
@@ -146,7 +146,7 @@ func (c *CF) Push(appName string) error {
 	cmd.Dir = c.envVar
 	cmd.Stdout = &msgWriter{"push", "stdout", c.out}
 	if err := cmd.Start(); err != nil {
-		fmt.Errorf("Error running cf push: ", err)
+		fmt.Errorf("Error running cf push: %s", err.Error())
 	}
 	cmd.Wait()
 	return nil
@@ -162,7 +162,7 @@ func (c *CF) Delete(appName string) error {
 	cmd.Stdout = &msgWriter{"delete", "stdout", c.out}
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("Error in cf delete: ", err)
+		return fmt.Errorf("Error in cf delete: %s", err.Error())
 	}
 
 	var msg []byte

--- a/commands/admin_actions.go
+++ b/commands/admin_actions.go
@@ -12,14 +12,14 @@ func Admin_CreateNewUser(basePath string, token string, configs *config.Config) 
 	cfAdmin := cf.NewCfAdmin(basePath, configs)
 	adminErr := cfAdmin.Login()
 	if adminErr != nil {
-		return nil, fmt.Errorf("Error logging in as admin: ", adminErr)
+		return nil, fmt.Errorf("Error logging in as admin: %s", adminErr.Error())
 	}
 
 	//create user
 	if adminErr == nil {
 		adminErr = cfAdmin.CreateUser(token)
 		if adminErr != nil {
-			return nil, fmt.Errorf("Error creating new user: ", adminErr)
+			return nil, fmt.Errorf("Error creating new user: %s", adminErr.Error())
 		}
 	}
 
@@ -27,7 +27,7 @@ func Admin_CreateNewUser(basePath string, token string, configs *config.Config) 
 	if adminErr == nil {
 		adminErr = cfAdmin.CreateSpace(token)
 		if adminErr != nil {
-			return nil, fmt.Errorf("Error creating new space: ", adminErr)
+			return nil, fmt.Errorf("Error creating new space: %s", adminErr.Error())
 		}
 	}
 
@@ -35,7 +35,7 @@ func Admin_CreateNewUser(basePath string, token string, configs *config.Config) 
 	if adminErr == nil {
 		adminErr = cfAdmin.AssignUserRole(token, token)
 		if adminErr != nil {
-			return nil, fmt.Errorf("Error assigning new user role: ", adminErr)
+			return nil, fmt.Errorf("Error assigning new user role: %s", adminErr.Error())
 		}
 	}
 


### PR DESCRIPTION
Hi

This PR fixes errors messages formatting.

Before:

```
mzh@Mzh-laptop:~/Development/go/src/github.com/cloudfoundry-community/cfplayground$ go run main.go 
Starting web ui on http://localhost:8080
Fatal Error
Error logging in as admin: %!(EXTRA *exec.ExitError=exit status 1)
exit status 1
```

After:

```
mzh@Mzh-laptop:~/Development/go/src/github.com/cloudfoundry-community/cfplayground$ go run main.go 
Starting web ui on http://localhost:8080
Fatal Error
Error logging in as admin: exit status 1
exit status 1
```
